### PR TITLE
update index and test to omit id:61 for GET providers

### DIFF
--- a/app/controllers/api/v1/providers_controller.rb
+++ b/app/controllers/api/v1/providers_controller.rb
@@ -1,6 +1,6 @@
 class Api::V1::ProvidersController < ApplicationController
   def index
-    providers = Provider.all
+    providers = Provider.where.not(id: 61)
     render json: ProviderSerializer.format_providers(providers)
   end
 

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -35,10 +35,6 @@ class Provider < ApplicationRecord
         provider_insurance.update!(accepted: false)
       end
     end
-    insurance_params.each do |insurance_info|
-      provider_insurance = ProviderInsurance.find_by(insurance_id: insurance_info[:id])
-      provider_insurance.update!(accepted: true)
-    end
   end
 
   def update_counties(counties_params)

--- a/spec/requests/api/v1/get_providers_request_spec.rb
+++ b/spec/requests/api/v1/get_providers_request_spec.rb
@@ -137,6 +137,25 @@ RSpec.describe "Get Providers Request", type: :request do
       end
     end
 
+    it "doesn't return provider id:61" do #this is the test provider id so we can live test updates with the deployed api
+      @provider_2 = Provider.create!(name: "Provider 2", website: "https://provider2.com", email: "contact@provider2.com")
+      @provider_61 = Provider.create!(id: 61, name: "Provider 61", website: "https://provider61.com", email: "contact@provider61.com")
+      
+      get "/api/v1/providers", headers: { 'Content-Type': 'application/json', 'Authorization': @api_key, 'Accept': 'application/json' }
+
+      expect(response).to be_successful
+      expect(response.status).to eq(200)
+
+      providers_response = JSON.parse(response.body, symbolize_names: true)
+
+      expect(providers_response[:data]).to be_a(Array)
+      expect(providers_response[:data].size).to eq(2)
+      
+      provider_ids = providers_response[:data].map { |provider| provider[:id] }
+      expect(provider_ids).to include(@provider.id)
+      expect(provider_ids).to include(@provider_2.id)
+      expect(provider_ids).not_to include(61)
+    end
 
     it "it throws error if not authorized with bearer token" do
 


### PR DESCRIPTION
## Type of Change
- [X] New Feature
- [ ] Debugging
- [ ] Refactor

## Describe Changes Made
- prep for setting up fake provider (id:61) in the production db for live testing updates
- update index so FE doesn't render it
- remove the "annabel" code from the helper method of update provider_insurances

## PR Checklist
- [X] Added Reviewer
- [X] Followed TDD, And Test are Passing
