### PR TITLE
Acj/auto create provider insurances

### DIFF
--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -38,6 +38,16 @@ class Provider < ApplicationRecord
     self.reload
   end
 
+  def initialize_provider_insurances
+    Insurance.all.each do |insurance|
+      ProviderInsurance.create!(
+        provider: self,
+        insurance: insurance,
+        accepted: false
+      )
+    end
+  end
+
   def update_provider_insurance(insurance_params)
     array = insurance_params.map do |param|
       param[:id]

--- a/spec/models/provider_insurance_spec.rb
+++ b/spec/models/provider_insurance_spec.rb
@@ -6,4 +6,25 @@ RSpec.describe ProviderInsurance, type: :model do
     it { should belong_to(:provider) }
     it { should belong_to(:insurance) }
   end
+
+  describe '#initialize_provider_insurances' do
+    it 'creates a ProviderInsurance record with accepted: false for each insurance' do
+      insurance1 = Insurance.create!(name: "Insurance A")
+      insurance2 = Insurance.create!(name: "Insurance B")
+      insurance3 = Insurance.create!(name: "Insurance C")
+
+      provider = Provider.create!(name: "Test Provider")
+
+      expect(ProviderInsurance.count).to eq(0)
+
+      provider.initialize_provider_insurances
+
+      expect(ProviderInsurance.count).to eq(3)
+
+      ProviderInsurance.all.each do |provider_insurance|
+        expect(provider_insurance.provider_id).to eq(provider.id)
+        expect(provider_insurance.accepted).to be_false
+      end
+    end
+  end
 end

--- a/spec/models/provider_insurance_spec.rb
+++ b/spec/models/provider_insurance_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe ProviderInsurance, type: :model do
 
       ProviderInsurance.all.each do |provider_insurance|
         expect(provider_insurance.provider_id).to eq(provider.id)
-        expect(provider_insurance.accepted).to be_false
+        expect(provider_insurance.accepted).to be false
       end
     end
   end

--- a/spec/requests/api/v1/create_provider_request_spec.rb
+++ b/spec/requests/api/v1/create_provider_request_spec.rb
@@ -12,8 +12,6 @@ RSpec.describe "Create Provider Request", type: :request do
 
   context "post /api/v1/providers" do
     it "creates a new provider and locations with associations to counties and insurances, then returns the created provider in json format" do
-
-
       provider_attributes = {
         "data": [
           {
@@ -156,6 +154,8 @@ RSpec.describe "Create Provider Request", type: :request do
 
       expect(Provider.all.count).to eq(1)
       expect(Provider.last.name).to eq("New Provider")
+
+      expect(Provider.last.provider_insurances.count).to eq(3)
     end
   end 
 end


### PR DESCRIPTION
## Type of Change
- [ ] New Feature
- [X] Debugging
- [ ] Refactor

## Describe Changes Made
Create action for Provider wasn't creating the provider insurances, so even superadmin couldn't add the right ones after creation. We were manually creating them in the Heroku CLI and setting all 33 to false.
I moved that step into the Create action and modified the Update action as well. 
Passing tests. 

**Before merging**, can we review in Postman? I'm having issues there getting Postman working with local server.

## PR Checklist
- [X] Added Reviewer
- [X] Followed TDD, And Test are Passing
