### PR TITLE
migrate new attribute, set enum, update serializer, update index action

### DIFF
--- a/app/controllers/api/v1/providers_controller.rb
+++ b/app/controllers/api/v1/providers_controller.rb
@@ -1,7 +1,14 @@
 class Api::V1::ProvidersController < ApplicationController
   def index
+    # binding.pry
     # providers = Provider.where.not(id: 61).where(status: :approved)
-    providers = Provider.where(status: :approved)
+    if params[:provider_type].present?
+      providers = Provider.where(status: :approved,provider_type: params[:provider_type])
+      binding.pry
+    else
+      binding.pry
+      providers = Provider.where(status: :approved)
+    end
     render json: ProviderSerializer.format_providers(providers)
   end
 

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -6,6 +6,8 @@ class Provider < ApplicationRecord
   has_many :insurances, through: :provider_insurances
 
   enum status: { pending: 1, approved: 2, denied: 3 }
+  enum provider_type: { aba_therapy: 0, autism_evaluation: 1 }
+
   #should refactor into smaller methods
   def update_locations(location_params)
     location_params_ids = location_params.map { |location| location[:id] }.compact

--- a/app/serializers/provider_serializer.rb
+++ b/app/serializers/provider_serializer.rb
@@ -9,6 +9,7 @@ class ProviderSerializer
           type: "provider",
           attributes: {
             "name": provider.name,
+            "provider_type": provider.provider_type,
             "locations": provider.locations.map do |location| 
               {
               id: location.id,

--- a/db/migrate/20241108212151_add_provider_type_to_providers.rb
+++ b/db/migrate/20241108212151_add_provider_type_to_providers.rb
@@ -1,0 +1,5 @@
+class AddProviderTypeToProviders < ActiveRecord::Migration[7.1]
+  def change
+    add_column :providers, :provider_type, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_10_14_175901) do
+ActiveRecord::Schema[7.1].define(version: 2024_11_08_212151) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -78,6 +78,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_14_175901) do
     t.datetime "updated_at", null: false
     t.string "logo"
     t.integer "status", default: 1, null: false
+    t.integer "provider_type", default: 0, null: false
   end
 
   add_foreign_key "counties", "providers"


### PR DESCRIPTION
## Type of Change
- [X] New Feature
- [ ] Debugging
- [ ] Refactor

## Describe Changes Made
We added a new attribute to Providers called `provider_type` and updated the serializer to send it to the FE. Tested in Postman.
`provider_type` will have only 2 types for now: "aba_therapy" and "autism_evaluation"
All existing providers were updated to "aba_therapy" using the enum default 0

## PR Checklist
- [X] Added Reviewer
- [ ] Followed TDD, And Test are Passing
