### PR TITLE
Fix logo URL generation for providers API

### DIFF
--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -36,7 +36,17 @@ class Provider < ApplicationRecord
     return nil if Rails.env.test?
     
     if logo.attached?
-      Rails.application.routes.url_helpers.rails_blob_url(logo)
+      # Use the configured host from development.rb
+      host = Rails.application.config.active_storage.default_url_options&.dig(:host)
+      port = Rails.application.config.active_storage.default_url_options&.dig(:port)
+      
+      if host.present?
+        host_with_port = port.present? ? "#{host}:#{port}" : host
+        Rails.application.routes.url_helpers.rails_blob_url(logo, host: host_with_port)
+      else
+        # Fallback to default behavior
+        Rails.application.routes.url_helpers.rails_blob_url(logo)
+      end
     elsif self[:logo].present?
       # Legacy logo field
       self[:logo]


### PR DESCRIPTION
- Fix Active Storage host configuration issue in Provider model
- Ensure logo URLs are generated with correct localhost:3000 host
- Resolves 500 Internal Server Error when fetching providers
- API now successfully returns providers with working logo URLs
- Users can now locate and view providers on the site

## Type of Change
- [ ] New Feature
- [x] Debugging
- [ ] Refactor

## Describe Changes Made


## PR Checklist
- [ ] Added Reviewer
- [ ] Followed TDD, And Test are Passing
