### PR TITLE
Add missing assign_provider_to_user endpoint to fix frontend 404 errors

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,6 +36,7 @@ Rails.application.routes.draw do
           get :my_providers
           get :accessible_providers
           post :set_active_provider
+          post :assign_provider_to_user
         end
         member do
           delete :remove_logo


### PR DESCRIPTION
- Add assign_provider_to_user method to ProvidersController
- Add route for POST /api/v1/providers/assign_provider_to_user
- Update skip_before_action to include new endpoint
- Fixes frontend errors when trying to assign users to providers
- Endpoint now properly validates users and providers
- Returns appropriate success/error responses

## Type of Change
- [ ] New Feature
- [ ] Debugging
- [ ] Refactor

## Describe Changes Made


## PR Checklist
- [ ] Added Reviewer
- [ ] Followed TDD, And Test are Passing
